### PR TITLE
Add S3 bucket for storing recipes json dumps

### DIFF
--- a/lib/__snapshots__/recipe-data-hackday-2023.test.ts.snap
+++ b/lib/__snapshots__/recipe-data-hackday-2023.test.ts.snap
@@ -115,6 +115,36 @@ exports[`The RecipeDataHackday2023 stack matches the snapshot 1`] = `
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
+    "StructuredRecipesFF7C8293": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "BucketName": "recipes",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "recipe-data-hackday-2023",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/recipe-data-hackday-2023",
+          },
+          {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
 }
 `;

--- a/lib/recipe-data-hackday-2023.ts
+++ b/lib/recipe-data-hackday-2023.ts
@@ -1,8 +1,7 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { Tags } from 'aws-cdk-lib';
+import { Tags, aws_s3 as s3 } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
-import { aws_s3 as s3 } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 
 export class RecipeDataHackday2023 extends GuStack {

--- a/lib/recipe-data-hackday-2023.ts
+++ b/lib/recipe-data-hackday-2023.ts
@@ -1,6 +1,6 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { Tags, aws_s3 as s3 } from 'aws-cdk-lib';
+import { aws_s3 as s3, Tags } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 
@@ -20,7 +20,9 @@ export class RecipeDataHackday2023 extends GuStack {
 			sortKey: { name: 'recipeId', type: AttributeType.NUMBER },
 		});
 
-		new s3.Bucket(this, 'StructuredRecipes'); 
+		new s3.Bucket(this, 'StructuredRecipes', {
+			bucketName: 'recipes',
+		}); 
 
 		Tags.of(this).add('App', 'recipe-data-hackday-2023');
 	}

--- a/lib/recipe-data-hackday-2023.ts
+++ b/lib/recipe-data-hackday-2023.ts
@@ -2,6 +2,7 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { Tags } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
+import { aws_s3 as s3 } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 
 export class RecipeDataHackday2023 extends GuStack {
@@ -19,6 +20,8 @@ export class RecipeDataHackday2023 extends GuStack {
 			partitionKey: { name: 'path', type: AttributeType.STRING },
 			sortKey: { name: 'recipeId', type: AttributeType.NUMBER },
 		});
+
+		new s3.Bucket(this, 'StructuredRecipes'); 
 
 		Tags.of(this).add('App', 'recipe-data-hackday-2023');
 	}


### PR DESCRIPTION
For people who prefer working with a flat file during the hack, this bucket can host those files.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
