### PR TITLE
fix: Change S3 bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Recipe Data, Hack Day 2023
 A copy of the databases from https://github.com/guardian/recipes, deployed to the Playground account for the food-themed Hack Day in May 2023.
 
-Find the data in the DynamoDb tables `recipes` and `recipes-edited`, within the Playground account, in `eu-west-1`.
+In the Playground account, within the `eu-west-1` region, find recipe data in:
+  - DynamoDb tables `recipes` and `recipes-edited`
+  - S3 bucket `recipe-data-hackday-2023`
 
-## Process
+## Data import process
 1. Export data from DynamoDb tables in the Composer account (`recipes`, and `recipes-edited`)
 2. Import the data into DynamoDb tables in the Playground account (`recipes`, and `recipes-edited`)
 

--- a/lib/__snapshots__/recipe-data-hackday-2023.test.ts.snap
+++ b/lib/__snapshots__/recipe-data-hackday-2023.test.ts.snap
@@ -118,7 +118,7 @@ exports[`The RecipeDataHackday2023 stack matches the snapshot 1`] = `
     "StructuredRecipesFF7C8293": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "BucketName": "recipes",
+        "BucketName": "recipe-data-hackday-2023",
         "Tags": [
           {
             "Key": "App",

--- a/lib/recipe-data-hackday-2023.ts
+++ b/lib/recipe-data-hackday-2023.ts
@@ -21,8 +21,8 @@ export class RecipeDataHackday2023 extends GuStack {
 		});
 
 		new s3.Bucket(this, 'StructuredRecipes', {
-			bucketName: 'recipes',
-		}); 
+			bucketName: 'recipe-data-hackday-2023',
+		});
 
 		Tags.of(this).add('App', 'recipe-data-hackday-2023');
 	}


### PR DESCRIPTION
## What does this change?
[Deployment](https://riffraff.gutools.co.uk/deployment/view/40adbf49-4726-4f98-b702-8f08382ec3a6) of #1 failed with:

```log
recipes already exists
```

As S3 buckets have a global namespace, this error suggests an S3 bucket named "recipes" exists elsewhere.

Change the name... and hope it's not taken!
